### PR TITLE
Typo read bioconductor packages

### DIFF
--- a/easy_annotate.py
+++ b/easy_annotate.py
@@ -142,11 +142,11 @@ class R(ExtsList):
 
         if 'bioconductor' in self.pkg_name.lower():
             self.bioconductor = True
-            self.read_bioconductor_pacakges()
+            self.read_bioconductor_packages()
         else:
             self.bioconductor = False
 
-    def read_bioconductor_pacakges(self):
+    def read_bioconductor_packages(self):
         """ read the Bioconductor package list into bio_data dict
             """
         self.bioc_urls = [

--- a/easy_update.py
+++ b/easy_update.py
@@ -490,12 +490,12 @@ class UpdateR(UpdateExts):
                 self.biocver = None
                 print('BioCondutor version: biocver not set')
         if self.biocver:
-            self.read_bioconductor_pacakges()
+            self.read_bioconductor_packages()
         self.updateexts()
         if eb:
             eb.print_update('R', self.exts_processed)
 
-    def read_bioconductor_pacakges(self):
+    def read_bioconductor_packages(self):
         """ read the Bioconductor package list into bio_data dict
         """
         base_url = 'https://bioconductor.org/packages/json/%s' % self.biocver


### PR DESCRIPTION
saw a typo in the method name i am sure this was unintended.