### PR TITLE
Canonicalize CRAN links

### DIFF
--- a/easy_annotate.py
+++ b/easy_annotate.py
@@ -171,7 +171,7 @@ class R(ExtsList):
                 description = cran_info[u'Title']
             except KeyError:
                 description = ''
-            url = 'https://cran.r-project.org/packages=%s' % pkg_name
+            url = 'https://cran.r-project.org/package=%s' % pkg_name
 
         return url, description
 

--- a/easy_annotate.py
+++ b/easy_annotate.py
@@ -171,7 +171,7 @@ class R(ExtsList):
                 description = cran_info[u'Title']
             except KeyError:
                 description = ''
-            url = 'https://cran.r-project.org/web/packages/%s/index.html' % pkg_name
+            url = 'https://cran.r-project.org/packages=%s' % pkg_name
 
         return url, description
 


### PR DESCRIPTION
[CRAN asks to use the `package=` URL variant](https://cran.r-project.org/doc/manuals/R-exts.html#Specifying-URLs) when linking to packages ;-) This PR results from a semi-automatic search-and-replace script and implements their suggestion.