### PR TITLE
Fix deprecated imp (since 3.4)

### DIFF
--- a/easy_update.py
+++ b/easy_update.py
@@ -4,7 +4,7 @@ import re
 import os
 import sys
 import argparse
-import imp
+import types
 import requests
 # from pprint import pprint
 # from pprint import pformat
@@ -121,7 +121,7 @@ class FrameWork:
                    'source/%(nameletter)s/%(name)s"\n')
         header += ('SOURCEFORGE_SOURCE = "https://download.sourceforge.net/' +
                    '%(namelower)s"\n')
-        eb = imp.new_module("EasyConfig")
+        eb = types.ModuleType("EasyConfig")
         try:
             with open(file_name, "r") as f:
                 code = f.read()


### PR DESCRIPTION
According to the [docs](https://docs.python.org/3/library/imp.html#imp.new_module) : `Deprecated since version 3.4: Use importlib.util.module_from_spec() instead.`.

Using `importlib.util.module_from_spec(None)` is not possible, therefore using `types.ModuleType()` is the solution.
