### PR TITLE
Increment requests to 2.22.0 to avoid clash with urllib3 requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 certifi==2018.11.29
 chardet==3.0.4
 idna==2.8
-requests==2.21.0
+requests==2.22.0
 urllib3==1.25.3
 packaging>=19.1


### PR DESCRIPTION
This fixes `pip` and `easy_update` warnings for me.