### PR TITLE
fix AttributeError for exts_defaultclass + add Python version check

### DIFF
--- a/easy_update.py
+++ b/easy_update.py
@@ -9,6 +9,11 @@ from framework import FrameWork
 from updateexts import UpdateExts
 from packaging.markers import Marker, UndefinedEnvironmentName
 
+# only works with Python 3 (due to use of isidentifier for example)
+if sys.version_info < (3,):
+    sys.stderr.write("ERROR: Python 3 required, found %s\n" % sys.version.split(' ')[0])
+    sys.exit(1)
+
 # from pprint import pprint
 
 """

--- a/framework.py
+++ b/framework.py
@@ -155,7 +155,7 @@ class FrameWork:
             self.lang = 'R'
             return
         if self.defaultclass:
-            self.lang = self.exts_defaultclass.replace('Package', '')
+            self.lang = eb.exts_defaultclass.replace('Package', '')
 
     def build_dep_filename(self, eb, dep):
         """build a filename from a dependencie object"""


### PR DESCRIPTION
I ran into this crash when trying to update `R-bundle-Bioconductor-3.10-foss-2020a.eb` (a copy of `R-bundle-Bioconductor-3.10-foss-2019b.eb` where toolchain and `dependencies` were bumped):

```
$ easy_update.py BioC.eb
 - reading dependency: R-3.6.3-foss-2020.eb
Traceback (most recent call last):
  File "/Users/kehoste/work/easy_update/easy_update.py", line 505, in <module>
    main()
  File "/Users/kehoste/work/easy_update/easy_update.py", line 480, in main
    eb = FrameWork(args)
  File "/Volumes/work/easy_update/framework.py", line 83, in __init__
    self.detect_language(eb)
  File "/Volumes/work/easy_update/framework.py", line 158, in detect_language
    self.lang = self.exts_defaultclass.replace('Package', '')
AttributeError: FrameWork instance has no attribute 'exts_defaultclass'
```

The change in `framework.py` fixes the bug.

I also noticed that `easy_update` failed with Python 2:

```
Traceback (most recent call last):
  File "/Users/kehoste/work/easy_update/easy_update.py", line 505, in <module>
    main()
  File "/Users/kehoste/work/easy_update/easy_update.py", line 480, in main
    eb = FrameWork(args)
  File "/Volumes/work/easy_update/framework.py", line 95, in __init__
    if 'eb.dependancies'.isidentifier():
AttributeError: 'str' object has no attribute 'isidentifier'
```

`isidentifier` is only supported in Python 3, so I've add a version check to `easy_update.py`
